### PR TITLE
Fix for click event not working with dialogs when clickOutsideToClose is enabled

### DIFF
--- a/addon/components/paper-dialog-inner.js
+++ b/addon/components/paper-dialog-inner.js
@@ -27,7 +27,6 @@ export default Component.extend(Translate3dMixin, {
   click(ev) {
     if (this.get('clickOutsideToClose')) {
       ev.stopPropagation();
-      return false;
     }
   }
 


### PR DESCRIPTION
Prevented "preventDefault" from occurring.
